### PR TITLE
Fix the super() takes at least 1 argument (0 given)

### DIFF
--- a/stack-inspector.py
+++ b/stack-inspector.py
@@ -77,7 +77,7 @@ class StackVisualizer(gdb.Command):
     """Inspect the stack for large objects"""
 
     def __init__(self):
-        super().__init__("stack-inspector", gdb.COMMAND_STACK)
+        super(StackVisualizer, self).__init__("stack-inspector", gdb.COMMAND_STACK)
 
     def invoke(self, arg, from_tty):
         try:


### PR DESCRIPTION
I got the below error. 
```
Traceback (most recent call last):
  File "/home/cefsimu/users/cvoica/stack-inspector.py", line 100, in <module>
    StackVisualizer()
  File "/home/cefsimu/users/cvoica/stack-inspector.py", line 80, in __init__
    super().__init__("stack-inspector", gdb.COMMAND_STACK)
TypeError: super() takes at least 1 argument (0 given)
```
This is one possible fix (I'm not a Python expert, just did what https://docs.quantifiedcode.com/python-anti-patterns/correctness/missing_argument_to_super.html says)